### PR TITLE
fix(pipelined): avoid cleaning up uplink-br0 in stateless mode.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -54,6 +54,7 @@ class UplinkBridgeController(MagmaController):
 
         self.config = self._get_config(kwargs['config'])
         self.logger.info("uplink bridge app config: %s", self.config)
+        self._clean_restart = kwargs['config']['clean_restart']
 
     def _get_config(self, config_dict) -> namedtuple:
 
@@ -185,8 +186,9 @@ class UplinkBridgeController(MagmaController):
         self._set_sgi_interface_ingress_flows()
 
     def cleanup_on_disconnect(self, datapath):
-        self._del_eth_port()
-        self._delete_all_flows()
+        if self._clean_restart:
+            self._del_eth_port()
+            self._delete_all_flows()
 
     def delete_all_flows(self, datapath):
         self._delete_all_flows()


### PR DESCRIPTION
Cleaning up uplink-br0 can disrupt traffic during service restart.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
